### PR TITLE
[android] experience fixes

### DIFF
--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -669,8 +669,9 @@
     <string name="unlimited">Unlimited</string>
     <string name="search_preferences_one_engine_checked_always">By default, one search engine needs to be checked at all times</string>
     <string name="number_picker_tip">Tip: touch selected number to use keyboard</string>
-    <string name="cannot_start_engine_without_vpn">BitTorrent can\'t be started unless a VPN connection is available. (Check your settings)</string>
+    <string name="cannot_start_engine_without_vpn">BitTorrent can\'t start unless a VPN is available. (Check your settings)</string>
     <string name="switch_off_engine_without_vpn">VPN is inactive, stopping the BitTorrent engine.</string>
-    <string name="mandatory_vpn_title">Use BitTorrent only with VPN connections</string>
-    <string name="mandatory_vpn_summary">Protect your privacy, automatically disable BitTorrent transfers unless an encrypted VPN connection is active</string>
+    <string name="mandatory_vpn_title">Use BitTorrent only with VPN</string>
+    <string name="mandatory_vpn_summary">Protect your privacy. Automatically disable BitTorrent transfers unless an encrypted VPN connection is active</string>
+    <string name="dismiss">Dismiss</string>
 </resources>

--- a/android/res/xml/settings_application.xml
+++ b/android/res/xml/settings_application.xml
@@ -25,15 +25,15 @@
             android:key="frostwire.prefs.internal.connect_disconnect"
             android:summary="@string/bittorrent_network_summary"
             android:title="@string/bittorrent" />
-        <android.support.v7.preference.SwitchPreferenceCompat
-            android:key="frostwire.prefs.network.bittorrent_on_vpn_only"
-            android:summary="@string/mandatory_vpn_summary"
-            android:title="@string/mandatory_vpn_title" />
         <!--  Wi-Fi Networks Only should replace Use 3G/4G for BitTorrent -->
         <android.support.v7.preference.SwitchPreferenceCompat
             android:key="frostwire.prefs.network.use_mobile_data"
             android:summary="@string/use_mobile_data_summary"
             android:title="@string/use_mobile_data" />
+        <android.support.v7.preference.SwitchPreferenceCompat
+            android:key="frostwire.prefs.network.bittorrent_on_vpn_only"
+            android:summary="@string/mandatory_vpn_summary"
+            android:title="@string/mandatory_vpn_title" />
         <com.frostwire.android.gui.views.preference.KitKatStoragePreference
             android:key="frostwire.prefs.storage.path"
             android:summary="@string/storage_preference_summary"

--- a/android/src/com/frostwire/android/gui/activities/MainActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/MainActivity.java
@@ -534,7 +534,7 @@ public class MainActivity extends AbstractActivity implements ConfigurationUpdat
         if (firstTime) {
             if (ConfigurationManager.instance().getBoolean(Constants.PREF_KEY_NETWORK_BITTORRENT_ON_VPN_ONLY) &&
                     !NetworkManager.instance().isTunnelUp()) {
-                UIUtils.showShortMessage(getWindow().getDecorView().getRootView(), R.string.cannot_start_engine_without_vpn);
+                UIUtils.showDismissableMessage(getWindow().getDecorView().getRootView(), R.string.cannot_start_engine_without_vpn);
             } else {
                 firstTime = false;
                 Engine.instance().startServices(); // it's necessary for the first time after wizard

--- a/android/src/com/frostwire/android/gui/util/UIUtils.java
+++ b/android/src/com/frostwire/android/gui/util/UIUtils.java
@@ -118,6 +118,20 @@ public final class UIUtils {
         Snackbar.make(view, resourceId, Snackbar.LENGTH_SHORT).show();
     }
 
+    public static void showLongMessage(View view, int resourceId) {
+        Snackbar.make(view, resourceId, Snackbar.LENGTH_LONG).show();
+    }
+
+    public static void showDismissableMessage(View view, int resourceId) {
+        final Snackbar snackbar = Snackbar.make(view, resourceId, Snackbar.LENGTH_INDEFINITE);
+        snackbar.setAction(R.string.dismiss, new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                snackbar.dismiss();
+            }
+        }).show();
+    }
+
     public static void sendShutdownIntent(Context ctx) {
         Intent i = new Intent(ctx, MainActivity.class);
         i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);


### PR DESCRIPTION
- wording to accomodate smaller screens
- setting goes below 3G/4G setting
- snackbar message on startup is so important it must be dismissable. new UIUtils.showDismissableMessage.

Functionality-wise, this branch is working great on my test device and ExpressVPN.

After this is merged I'll probably implement a custom layout for the setting to include a "Get a VPN" link on the setting summary.